### PR TITLE
KolodaViewDelegate functions are practically optional

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -49,6 +49,13 @@ public protocol KolodaViewDelegate:class {
     
 }
 
+public extension KolodaViewDelegate {
+    func kolodaDidSwipedCardAtIndex(koloda: KolodaView,index: UInt, direction: SwipeResultDirection) {}
+    func kolodaDidRunOutOfCards(koloda: KolodaView) {}
+    func kolodaDidSelectCardAtIndex(koloda: KolodaView, index: UInt) {}
+    func kolodaShouldApplyAppearAnimation(koloda: KolodaView) -> Bool {return false}
+}
+
 public class KolodaView: UIView, DraggableCardDelegate {
     
     public weak var dataSource: KolodaViewDataSource! {


### PR DESCRIPTION
none of KolodaViewDelegate functions are essential for KolodaView to work properly
they all must be optional but as @objc cannot be applied, i did this workaround