### PR TITLE
Makes method layoutDeck() public

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -125,7 +125,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
         }
     }
     
-    private func layoutDeck() {
+    public func layoutDeck() {
         for (index, card) in enumerate(self.visibleCards) {
             card.frame = frameForCardAtIndex(UInt(index))
         }


### PR DESCRIPTION
By making `layoutDeck()` public, end users may trigger layout updates. For example, the layout can change sizes correctly when the device is rotated. This resolves #19 .