### PR TITLE
Enable cards to be touched when they have finished dragging

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -45,6 +45,7 @@ public class DraggableCardView: UIView {
     private var xDistanceFromCenter: CGFloat = 0.0
     private var yDistanceFromCenter: CGFloat = 0.0
     private var actionMargin: CGFloat = 0.0
+    private var firstTouch = true
     
     //MARK: Lifecycle
     init() {
@@ -190,7 +191,10 @@ public class DraggableCardView: UIView {
         
         switch gestureRecognizer.state {
         case .Began:
-            originalLocation = center
+            if firstTouch {
+                originalLocation = center
+                firstTouch = false
+            }
             dragBegin = true
             
             animationDirection = touchLocation.y >= frame.size.height / 2 ? -1.0 : 1.0
@@ -296,7 +300,6 @@ public class DraggableCardView: UIView {
     }
     
     private func resetViewPositionAndTransformations() {
-        userInteractionEnabled = false
         self.delegate?.cardWasReset(self)
         
         let resetPositionAnimation = POPSpringAnimation(propertyNamed: kPOPLayerPosition)
@@ -307,7 +310,6 @@ public class DraggableCardView: UIView {
         resetPositionAnimation.completionBlock = {
             (_, _) in
             
-            self.userInteractionEnabled = true
             self.dragBegin = false
         }
         
@@ -315,7 +317,7 @@ public class DraggableCardView: UIView {
         
         UIView.animateWithDuration(cardResetAnimationDuration,
             delay: 0.0,
-            options: .CurveLinear,
+            options: (.CurveLinear | .AllowUserInteraction),
             animations: {
                 self.transform = CGAffineTransformMakeRotation(0)
                 self.overlayView?.alpha = 0


### PR DESCRIPTION
Currently, when the user drags a card a short way and releases, the card animates back to the center. During this reset animation, the user cannot interact with the card. This can be frustrating to the user because the app feels (and, in fact, is) unresponsive during this time.

This pull request allows the card to be interacted with while it is resetting.

Due to issues with how the "center" is calculated, the center can shift if the card is rapidly dragged and re-dragged before it hits the center again. The DraggableCardView now stores its center only the very first time the card is dragged. There may be a more optimal approach.