### PR TITLE
Fixes #50 by changing setupDeck to load cards based on currentCardNumber

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -145,19 +145,19 @@ public class KolodaView: UIView, DraggableCardDelegate {
             
             let countOfNeededCards = min(countOfVisibleCards, countOfCards - currentCardNumber)
             
-            for index in currentCardNumber..<(currentCardNumber+countOfNeededCards) {
-                if let nextCardContentView = dataSource?.kolodaViewForCardAtIndex(self, index: UInt(index)) {
+            for index in 0..<countOfNeededCards {
+                if let nextCardContentView = dataSource?.kolodaViewForCardAtIndex(self, index: UInt(index+currentCardNumber)) {
                     let nextCardView = DraggableCardView(frame: frameForCardAtIndex(UInt(index)))
                     
                     nextCardView.delegate = self
-                    nextCardView.alpha = index == currentCardNumber ? alphaValueOpaque : alphaValueSemiTransparent
-                    nextCardView.userInteractionEnabled = index == currentCardNumber
+                    nextCardView.alpha = index == 0 ? alphaValueOpaque : alphaValueSemiTransparent
+                    nextCardView.userInteractionEnabled = index == 0
                     
-                    let overlayView = overlayViewForCardAtIndex(UInt(index))
+                    let overlayView = overlayViewForCardAtIndex(UInt(index+currentCardNumber))
                     
                     nextCardView.configure(nextCardContentView, overlayView: overlayView)
                     visibleCards.append(nextCardView)
-                    index == currentCardNumber ? addSubview(nextCardView) : insertSubview(nextCardView, belowSubview: visibleCards[index - 1])
+                    index == 0 ? addSubview(nextCardView) : insertSubview(nextCardView, belowSubview: visibleCards[index - 1])
                 }
             }
         }

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -145,19 +145,19 @@ public class KolodaView: UIView, DraggableCardDelegate {
             
             let countOfNeededCards = min(countOfVisibleCards, countOfCards - currentCardNumber)
             
-            for index in 0..<countOfNeededCards {
+            for index in currentCardNumber..<(currentCardNumber+countOfNeededCards) {
                 if let nextCardContentView = dataSource?.kolodaViewForCardAtIndex(self, index: UInt(index)) {
                     let nextCardView = DraggableCardView(frame: frameForCardAtIndex(UInt(index)))
                     
                     nextCardView.delegate = self
-                    nextCardView.alpha = index == 0 ? alphaValueOpaque : alphaValueSemiTransparent
-                    nextCardView.userInteractionEnabled = index == 0
+                    nextCardView.alpha = index == currentCardNumber ? alphaValueOpaque : alphaValueSemiTransparent
+                    nextCardView.userInteractionEnabled = index == currentCardNumber
                     
                     let overlayView = overlayViewForCardAtIndex(UInt(index))
                     
                     nextCardView.configure(nextCardContentView, overlayView: overlayView)
                     visibleCards.append(nextCardView)
-                    index == 0 ? addSubview(nextCardView) : insertSubview(nextCardView, belowSubview: visibleCards[index - 1])
+                    index == currentCardNumber ? addSubview(nextCardView) : insertSubview(nextCardView, belowSubview: visibleCards[index - 1])
                 }
             }
         }


### PR DESCRIPTION
Fixes #50 by changing `setupDeck` to load cards based on `currentCardNumber`, rather than the current behavior (loading cards starting at 0). The main effect of this pull request is that if cards are dynamically added after the deck is exhausted, new cards will be shown, rather than card #0.