### PR TITLE
Fixed #61 by not force unwrapping visibleCards.last optional

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -354,7 +354,11 @@ public class KolodaView: UIView, DraggableCardDelegate {
                 
                 lastCardView.delegate = self
                 
-                insertSubview(lastCardView, belowSubview: visibleCards.last!)
+                if let lastCard = visibleCards.last {
+                    insertSubview(lastCardView, belowSubview:lastCard)
+                } else {
+                    addSubview(lastCardView)
+                }
                 visibleCards.append(lastCardView)
             }
         }


### PR DESCRIPTION
As a general rule of thumb, force unwraps should be avoided in nearly all cases. There might be some more crashes lurking in the codebase.