### PR TITLE
Issue #55 workaround for CocoaPod issue 4420

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -5,3 +5,6 @@ target 'Koloda_Example', :exclusive => true do
   pod "Koloda", :path => "../"
 end
 
+post_install do |installer|
+  `find Pods -regex 'Pods/pop.*\\.h' -print0 | xargs -0 sed -i '' 's/\\(<\\)pop\\/\\(.*\\)\\(>\\)/\\"\\2\\"/'`
+end


### PR DESCRIPTION
This is to make sure the example actually works out-of-the-box. I had to spent too much time tracking down why the example wouldn't build. 

We can always revert the workaround once CocoaPod fixes their issue.

Fixes #55 