### PR TITLE
Expose method for overriding card `actionMargin`

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -15,7 +15,7 @@ protocol DraggableCardDelegate: class {
     func card(card: DraggableCardView, wasSwipedInDirection direction: SwipeResultDirection)
     func card(cardWasReset card: DraggableCardView)
     func card(cardWasTapped card: DraggableCardView)
-    func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat
+    func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat?
 }
 
 //Drag animation constants

--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -15,6 +15,7 @@ protocol DraggableCardDelegate: class {
     func card(card: DraggableCardView, wasSwipedInDirection direction: SwipeResultDirection)
     func card(cardWasReset card: DraggableCardView)
     func card(cardWasTapped card: DraggableCardView)
+    func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat
 }
 
 //Drag animation constants
@@ -61,7 +62,7 @@ public class DraggableCardView: UIView {
     
     override public var frame: CGRect {
         didSet {
-            actionMargin = frame.size.width / 2.0
+            actionMargin = delegate?.card(cardSwipeThresholdMargin: self) ?? frame.size.width / 2.0
         }
     }
     

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -67,6 +67,7 @@ public protocol KolodaViewDelegate:class {
     func koloda(kolodaShouldTransparentizeNextCard koloda: KolodaView) -> Bool
     func koloda(kolodaBackgroundCardAnimation koloda: KolodaView) -> POPPropertyAnimation?
     func koloda(koloda: KolodaView, draggedCardWithFinishPercent finishPercent: CGFloat, inDirection direction: SwipeResultDirection)
+    func koloda(kolodaSwipeThresholdMargin koloda: KolodaView) -> CGFloat?
 }
 
 public extension KolodaViewDelegate {
@@ -79,6 +80,7 @@ public extension KolodaViewDelegate {
     func koloda(kolodaShouldTransparentizeNextCard koloda: KolodaView) -> Bool {return true}
     func koloda(kolodaBackgroundCardAnimation koloda: KolodaView) -> POPPropertyAnimation? {return nil}
     func koloda(koloda: KolodaView, draggedCardWithFinishPercent finishPercent: CGFloat, inDirection direction: SwipeResultDirection) {}
+    func koloda(kolodaSwipeThresholdMargin koloda: KolodaView) -> CGFloat? {return nil}
 }
 
 public class KolodaView: UIView, DraggableCardDelegate {
@@ -319,6 +321,10 @@ public class KolodaView: UIView, DraggableCardDelegate {
         let index = currentCardNumber + visibleCards.indexOf(card)!
         
         delegate?.koloda(self, didSelectCardAtIndex: UInt(index))
+    }
+    
+    func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat {
+        return delegate?.koloda(kolodaSwipeThresholdMargin: self) ?? card.frame.size.width / 2.0
     }
     
     //MARK: Private

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -327,8 +327,8 @@ public class KolodaView: UIView, DraggableCardDelegate {
         delegate?.koloda(self, didSelectCardAtIndex: UInt(index))
     }
     
-    func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat {
-        return delegate?.koloda(kolodaSwipeThresholdMargin: self) ?? card.frame.size.width / 2.0
+    func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat? {
+        return delegate?.koloda(kolodaSwipeThresholdMargin: self)
     }
     
     //MARK: Private

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Return a pop frame animation to be applied to backround cards after swipe. This 
 func koloda(koloda: KolodaView, draggedCardWithFinishPercent finishPercent: CGFloat, inDirection direction: SwipeResultDirection)
 ```
 This method is called whenever the KolodaView recognizes card dragging event. 
+```swift
+func koloda(kolodaSwipeThresholdMargin koloda: KolodaView) -> CGFloat?
+```
+Return the distance that a card may be dragged in order to trigger a swipe. The default behavior (or returning NIL) will set this threshold to half of the card's width
 
 Release Notes
 ----------------


### PR DESCRIPTION
Some of our end users have been commenting on how taxing it is to swipe cards. Allowing the ability to override the swipe distance might prove useful for some.