### PR TITLE
Returning 'false' in 'kolodaShouldTransparentizeNextCard' is broken.

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -5,3 +5,6 @@ target 'Koloda_Example', :exclusive => true do
   pod "Koloda", :path => "../"
 end
 
+post_install do |installer|
+  `find Pods -regex 'Pods/pop.*\\.h' -print0 | xargs -0 sed -i '' 's/\\(<\\)pop\\/\\(.*\\)\\(>\\)/\\"\\2\\"/'`
+end

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -165,7 +165,9 @@ public class KolodaView: UIView, DraggableCardDelegate {
                     let nextCardView = DraggableCardView(frame: frameForCardAtIndex(UInt(index)))
                     
                     nextCardView.delegate = self
-                    nextCardView.alpha = index == 0 ? alphaValueOpaque : alphaValueSemiTransparent
+                    if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
+                        nextCardView.alpha = index == 0 ? alphaValueOpaque : alphaValueSemiTransparent
+                    }
                     nextCardView.userInteractionEnabled = index == 0
                     
                     let overlayView = overlayViewForCardAtIndex(UInt(index+currentCardNumber))
@@ -315,7 +317,9 @@ public class KolodaView: UIView, DraggableCardDelegate {
                     
                     for index in 1..<self.visibleCards.count {
                         let card = self.visibleCards[index]
-                        card.alpha = self.alphaValueSemiTransparent
+                        if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
+                            card.alpha = index == 0 ? self.alphaValueOpaque : self.alphaValueSemiTransparent
+                        }
                     }
             })
         } else {
@@ -395,11 +399,12 @@ public class KolodaView: UIView, DraggableCardDelegate {
                     (frameAnimation as! POPBasicAnimation).duration = backgroundCardFrameAnimationDuration
                 }
                 
-                let shouldTransparentize = delegate?.koloda(kolodaShouldTransparentizeNextCard: self)
                 let cardFrame = frameForCardAtIndex(UInt(index))
                 
                 if index != 0 {
-                    currentCard.alpha = alphaValueSemiTransparent
+                    if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
+                        currentCard.alpha = alphaValueSemiTransparent
+                    }
                 } else {
                     frameAnimation.completionBlock = {(animation, finished) in
                         self.visibleCards.last?.hidden = false
@@ -407,11 +412,11 @@ public class KolodaView: UIView, DraggableCardDelegate {
                         currentCard.frame = cardFrame
                         self.delegate?.koloda(self, didSwipedCardAtIndex: UInt(self.currentCardNumber - 1), inDirection: direction)
                         self.delegate?.koloda(self, didShowCardAtIndex: UInt(self.currentCardNumber))
-                        if (shouldTransparentize == false) {
+                        if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
                             currentCard.alpha = self.alphaValueOpaque
                         }
                     }
-                    if (shouldTransparentize == true) {
+                    if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
                         currentCard.alpha = alphaValueOpaque
                     } else {
                         let alphaAnimation = POPBasicAnimation(propertyNamed: kPOPViewAlpha)
@@ -454,7 +459,9 @@ public class KolodaView: UIView, DraggableCardDelegate {
                 let firstCardOverlayView = dataSource.koloda(self, viewForCardOverlayAtIndex: UInt(currentCardNumber))
                 let firstCardView = DraggableCardView()
                 
-                firstCardView.alpha = alphaValueTransparent
+                if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
+                    firstCardView.alpha = alphaValueTransparent
+                }
                 
                 firstCardView.configure(firstCardContentView, overlayView: firstCardOverlayView)
                 firstCardView.delegate = self
@@ -474,7 +481,9 @@ public class KolodaView: UIView, DraggableCardDelegate {
                 let frameAnimation = POPBasicAnimation(propertyNamed: kPOPViewFrame)
                 
                 frameAnimation.duration = backgroundCardFrameAnimationDuration
-                currentCard.alpha = alphaValueSemiTransparent
+                if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
+                    currentCard.alpha = alphaValueSemiTransparent
+                }
                 frameAnimation.toValue = NSValue(CGRect: frameForCardAtIndex(UInt(index)))
                 currentCard.userInteractionEnabled = false
                 
@@ -491,7 +500,9 @@ public class KolodaView: UIView, DraggableCardDelegate {
             for index in 1...cardsToAdd {
                 let nextCardView = DraggableCardView(frame: frameForCardAtIndex(UInt(index)))
                 
-                nextCardView.alpha = alphaValueSemiTransparent
+                if let shouldTransparentize = self.delegate?.koloda(kolodaShouldTransparentizeNextCard: self) where shouldTransparentize == true {
+                    nextCardView.alpha = alphaValueSemiTransparent
+                }
                 nextCardView.delegate = self
                 
                 visibleCards.append(nextCardView)


### PR DESCRIPTION
When returning false in ```kolodaShouldTransparentizeNextCard```, the cards were still animating the transparency.

Also fixed example podfile for user's getting compiler errors for 'pop' library.