### PR TITLE
Allow user to configure if the card should be draggable

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -16,7 +16,9 @@ protocol DraggableCardDelegate: class {
     func card(cardWasReset card: DraggableCardView)
     func card(cardWasTapped card: DraggableCardView)
     func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat?
+    func card(cardShouldDrag card: DraggableCardView) -> Bool
 }
+
 
 //Drag animation constants
 private let rotationMax: CGFloat = 1.0
@@ -30,7 +32,7 @@ private let cardResetAnimationSpringSpeed: CGFloat = 20.0
 private let cardResetAnimationKey = "resetPositionAnimation"
 private let cardResetAnimationDuration: NSTimeInterval = 0.2
 
-public class DraggableCardView: UIView {
+public class DraggableCardView: UIView, UIGestureRecognizerDelegate {
     
     weak var delegate: DraggableCardDelegate?
     
@@ -74,6 +76,7 @@ public class DraggableCardView: UIView {
     private func setup() {
         panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(DraggableCardView.panGestureRecognized(_:)))
         addGestureRecognizer(panGestureRecognizer)
+        panGestureRecognizer.delegate = self
         tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(DraggableCardView.tapRecognized(_:)))
         addGestureRecognizer(tapGestureRecognizer)
     }
@@ -226,6 +229,10 @@ public class DraggableCardView: UIView {
         default :
             break
         }
+    }
+    
+    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
+        return delegate?.card(cardShouldDrag: self) ?? true
     }
     
     func tapRecognized(recogznier: UITapGestureRecognizer) {

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -299,8 +299,9 @@ public class KolodaView: UIView, DraggableCardDelegate {
     }
     
     func card(cardShouldDrag card: DraggableCardView) -> Bool {
-        let index = currentCardIndex + visibleCards.indexOf(card)!
+        guard let visibleIndex = visibleCards.indexOf(card) else { return true}
         
+        let index = currentCardIndex + visibleIndex
         return delegate?.koloda(self, shouldDragCardAtIndex: UInt(index)) ?? true
     }
     

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -53,6 +53,7 @@ public protocol KolodaViewDelegate:class {
     func kolodaDidResetCard(koloda: KolodaView)
     func kolodaSwipeThresholdMargin(koloda: KolodaView) -> CGFloat?
     func koloda(koloda: KolodaView, didShowCardAtIndex index: UInt)
+    func koloda(koloda: KolodaView, shouldDragCardAtIndex index: UInt ) -> Bool
 }
 
 public extension KolodaViewDelegate {
@@ -67,7 +68,7 @@ public extension KolodaViewDelegate {
     func kolodaDidResetCard(koloda: KolodaView) {}
     func kolodaSwipeThresholdMargin(koloda: KolodaView) -> CGFloat? { return nil}
     func koloda(koloda: KolodaView, didShowCardAtIndex index: UInt) {}
-    
+    func koloda(koloda: KolodaView, shouldDragCardAtIndex index: UInt ) -> Bool { return true }
 }
 
 public class KolodaView: UIView, DraggableCardDelegate {
@@ -287,6 +288,12 @@ public class KolodaView: UIView, DraggableCardDelegate {
     
     func card(cardSwipeThresholdMargin card: DraggableCardView) -> CGFloat? {
         return delegate?.kolodaSwipeThresholdMargin(self)
+    }
+    
+    func card(cardShouldDrag card: DraggableCardView) -> Bool {
+        let index = currentCardIndex + visibleCards.indexOf(card)!
+        
+        return delegate?.koloda(self, shouldDragCardAtIndex: UInt(index)) ?? true
     }
     
     //MARK: Private

--- a/README.md
+++ b/README.md
@@ -178,7 +178,12 @@ This method is fired after resetting the card.
 func koloda(koloda: KolodaView, didShowCardAtIndex index: UInt)
 ```
 This method is called after a card has been shown, after animation is complete
-
+```swift
+func koloda(koloda: KolodaView, shouldDragCardAtIndex index: UInt ) -> Bool
+```
+This method is called when the card is beginning to be dragged. If you return YES from the method or
+don't implement it, the card will move in the direction of the drag. If you return NO the card will
+not move.
 
 Release Notes
 ----------------


### PR DESCRIPTION
I added the ability for a user to configure if dragging is enabled for a given card via a delegate method 
`func koloda(koloda: KolodaView, shouldDragCardAtIndex index: UInt ) -> Bool
`
If you don't implement it or return true, the card will drag normally. If you return false, the card won't move at all. 

I needed this for a personal project where I wanted to allow for user interaction on the card itself, but didn't want it to move until certain conditions were met. 