### PR TITLE
Disallow canceling touches in subviews

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -85,6 +85,7 @@ public class DraggableCardView: UIView, UIGestureRecognizerDelegate {
         addGestureRecognizer(panGestureRecognizer)
         panGestureRecognizer.delegate = self
         tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(DraggableCardView.tapRecognized(_:)))
+        tapGestureRecognizer.cancelsTouchesInView = false
         addGestureRecognizer(tapGestureRecognizer)
     }
     


### PR DESCRIPTION
When I use an `UICollectionView` as a subview of a `DraggableCardView`, `didSelectItemAtIndexPath` delegate method is not called. The reason is that `cancelsTouchesInView` property of `tapGestureRecognizer` of `DraggableCardView` equal to `true`. 

Changed `cancelsTouchesInView` to `false` and everything became working as expected.