### PR TITLE
Fix index out of range when removing all cards

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -637,6 +637,8 @@ public class KolodaView: UIView, DraggableCardDelegate {
         
         animating = true
         let currentItemsCount = countOfCards
+        countOfCards = Int(dataSource.kolodaNumberOfCards(self))
+
         let visibleIndexes = [Int](indexRange).filter { $0 >= currentCardIndex && $0 < currentCardIndex + countOfVisibleCards }
         if !visibleIndexes.isEmpty {
             proceedDeletionInRange(visibleIndexes[0]..<visibleIndexes[visibleIndexes.count - 1])
@@ -649,7 +651,6 @@ public class KolodaView: UIView, DraggableCardDelegate {
         }
         animating = false
         
-        countOfCards = Int(dataSource.kolodaNumberOfCards(self))
         assert(
             currentItemsCount - indexRange.count == countOfCards,
             "Cards count after update is not equal to data source count"


### PR DESCRIPTION
When trying to remove all cards from the Koloda view I get a Out Of Bound error. I think the issue is that we don't update the new countOfCards soon enough. So when we try to get the missingCardCount it returns an incorrect number (not zero in this case).

This function is called before we update the countOfCards:
```
 private func missingCardsCount() -> Int {
       return min(countOfVisibleCards - visibleCards.count, countOfCards - (currentCardIndex + 1))
    }
```

So I just moved the statement earlier in the function.

Welcome to all feedbacks