### PR TITLE
Fixed card insertion after removing first card

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -657,6 +657,11 @@ public class KolodaView: UIView, DraggableCardDelegate {
         let visibleIndexes = [Int](indexRange).filter { $0 >= currentCardIndex && $0 < currentCardIndex + countOfVisibleCards }
         if !visibleIndexes.isEmpty {
             proceedDeletionInRange(visibleIndexes[0]..<visibleIndexes[visibleIndexes.count - 1])
+            
+            // Update current card index if the first visible card has been removed
+            if visibleIndexes[0] == currentCardIndex {
+                currentCardIndex += visibleRange.count
+            }
         }
         loadMissingCards(missingCardsCount())
         layoutDeck()

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -657,7 +657,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
         if !visibleIndexes.isEmpty {
             proceedDeletionInRange(visibleIndexes[0]...visibleIndexes[visibleIndexes.count - 1])
         }
-        currentCardIndex -= Array(indexRange).filter { $0 < currentCardIndex }.count
+        currentCardIndex += Array(indexRange).filter { $0 < currentCardIndex }.count
         loadMissingCards(missingCardsCount())
         layoutDeck()
         for (index, card) in visibleCards.enumerate() {

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -657,11 +657,6 @@ public class KolodaView: UIView, DraggableCardDelegate {
         let visibleIndexes = [Int](indexRange).filter { $0 >= currentCardIndex && $0 < currentCardIndex + countOfVisibleCards }
         if !visibleIndexes.isEmpty {
             proceedDeletionInRange(visibleIndexes[0]..<visibleIndexes[visibleIndexes.count - 1])
-            
-            // Update current card index if the first visible card has been removed
-            if visibleIndexes[0] == currentCardIndex {
-                currentCardIndex += visibleIndexes.count
-            }
         }
         loadMissingCards(missingCardsCount())
         layoutDeck()

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -660,7 +660,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
             
             // Update current card index if the first visible card has been removed
             if visibleIndexes[0] == currentCardIndex {
-                currentCardIndex += visibleRange.count
+                currentCardIndex += visibleIndexes.count
             }
         }
         loadMissingCards(missingCardsCount())

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -469,7 +469,11 @@ public class KolodaView: UIView, DraggableCardDelegate {
                 
                 visibleCards.append(nextCardView)
                 configureCard(nextCardView, atIndex: UInt(currentCardIndex + index))
-                insertSubview(nextCardView, belowSubview: visibleCards[index - 1])
+                if index > 0 {
+                    insertSubview(nextCardView, belowSubview: visibleCards[index - 1])
+                } else {
+                    insertSubview(nextCardView, atIndex: 0)
+                }
             }
         }
     }


### PR DESCRIPTION
This issue occures when removing the very first card with removeCardInIndexRange.
The `index` variable used to get a visible card is equals to 0. Then it tries to get index `-1` of the `visibleCards` array.