### PR TITLE
Call a delegate when a card really swiped out (closes #125)

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -12,6 +12,7 @@ import pop
 protocol DraggableCardDelegate: class {
     
     func card(card: DraggableCardView, wasDraggedWithFinishPercentage percentage: CGFloat, inDirection direction: SwipeResultDirection)
+    func card(card: DraggableCardView, willBeSwipedInDirection direction: SwipeResultDirection)
     func card(card: DraggableCardView, wasSwipedInDirection direction: SwipeResultDirection)
     func card(card: DraggableCardView, shouldSwipeInDirection direction: SwipeResultDirection) -> Bool
     func card(cardWasReset card: DraggableCardView)
@@ -384,14 +385,14 @@ public class DraggableCardView: UIView, UIGestureRecognizerDelegate {
     
     func swipe(direction: SwipeResultDirection) {
         if !dragBegin {
-            delegate?.card(self, wasSwipedInDirection: direction)
+             self.delegate?.card(self, willBeSwipedInDirection: direction)
             
             let swipePositionAnimation = POPBasicAnimation(propertyNamed: kPOPLayerTranslationXY)
             swipePositionAnimation.fromValue = NSValue(CGPoint:POPLayerGetTranslationXY(layer))
             swipePositionAnimation.toValue = NSValue(CGPoint:animationPointForDirection(direction))
             swipePositionAnimation.duration = cardSwipeActionAnimationDuration
-            swipePositionAnimation.completionBlock = {
-                (_, _) in
+            swipePositionAnimation.completionBlock = { _, _ in
+                self.delegate?.card(self, wasSwipedInDirection: direction)
                 self.removeFromSuperview()
             }
             

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -265,8 +265,16 @@ public class KolodaView: UIView, DraggableCardDelegate {
         return delegate?.koloda(self, allowedDirectionsForIndex: UInt(index)) ?? [.Left, .Right]
     }
     
+    func card(card: DraggableCardView, willBeSwipedInDirection direction: SwipeResultDirection) {
+         swipedAction(direction)
+    }
+    
     func card(card: DraggableCardView, wasSwipedInDirection direction: SwipeResultDirection) {
-        swipedAction(direction)
+        if visibleCards.isEmpty {
+            animating = false
+            delegate?.koloda(self, didSwipeCardAtIndex: UInt(self.currentCardIndex - 1), inDirection: direction)
+            delegate?.kolodaDidRunOutOfCards(self)
+        }
     }
     
     func card(cardWasReset card: DraggableCardView) {
@@ -344,10 +352,6 @@ public class KolodaView: UIView, DraggableCardDelegate {
                 _self.delegate?.koloda(_self, didSwipeCardAtIndex: UInt(_self.currentCardIndex - 1), inDirection: direction)
                 _self.delegate?.koloda(_self, didShowCardAtIndex: UInt(_self.currentCardIndex))
             }
-        } else {
-            animating = false
-            delegate?.koloda(self, didSwipeCardAtIndex: UInt(self.currentCardIndex - 1), inDirection: direction)
-            delegate?.kolodaDidRunOutOfCards(self)
         }
     }
     
@@ -532,7 +536,6 @@ public class KolodaView: UIView, DraggableCardDelegate {
                     nextCard.alpha = shouldTransparentizeNextCard ? alphaValueSemiTransparent : alphaValueOpaque
                 }
                 frontCard.swipe(direction)
-                frontCard.delegate = nil
             }
         }
     }


### PR DESCRIPTION
I have a question: is it necessary to set delegate to nil for cards?