### PR TITLE
check swipable when swipe manually

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -518,7 +518,12 @@ public class KolodaView: UIView, DraggableCardDelegate {
         }
     }
     
-    public func swipe(direction: SwipeResultDirection) {
+    public func swipe(direction: SwipeResultDirection,force: Bool = true) {
+        
+        let shouldSwipe = delegate?.koloda(self, shouldSwipeCardAtIndex: UInt(self.currentCardIndex), inDirection: direction) ?? true
+        guard force || shouldSwipe else {
+            return
+        }
         
         let validDirection = delegate?.koloda(self, allowedDirectionsForIndex: UInt(currentCardIndex)).contains(direction) ?? true
         guard validDirection else { return }


### PR DESCRIPTION
Awesome Lib! thank you for your sharing! :)

On implementing a button swipe cards manually (like nope, thank button),
there is no check swipable by delegate method "shouldSwipeCardAtIndex".

therefore,I can swipe cards by tapping button unintensionally.

so I add force swipe option to method "swipe(direction: SwipeResultDirection)".
default value of force option is "true" in order not to affect the existing specifications.