### PR TITLE
Passthrough taps should be detected only within view bounds

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -560,7 +560,12 @@ public class KolodaView: UIView, DraggableCardDelegate {
             return super.pointInside(point, withEvent: event)
         }
         
-        return visibleCards.count > 0
+        if super.pointInside(point, withEvent: event) {
+            return visibleCards.count > 0
+        }
+        else {
+            return false
+        }
     }
     
     // MARK: Cards managing - Insertion


### PR DESCRIPTION
Hi there, when `shouldPassthroughTapsWhenNoVisibleCards` is enabled, then the `KolodaView` captures all taps even outside of its bounds. Added a checking.
