### PR TITLE
Fixed the linker issue when using Carthage to build Koloda library with Xcode 8

### DIFF
--- a/Koloda.xcodeproj/project.pbxproj
+++ b/Koloda.xcodeproj/project.pbxproj
@@ -144,7 +144,6 @@
 				C517E4A71D9CF9010002D88F /* Frameworks */,
 				C517E4A81D9CF9010002D88F /* Headers */,
 				C517E4A91D9CF9010002D88F /* Resources */,
-				C517E4F61D9D01120002D88F /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -196,24 +195,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		C517E4F61D9D01120002D88F /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/pop.framework",
-			);
-			name = Carthage;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C517E4A61D9CF9010002D88F /* Sources */ = {

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -90,7 +90,7 @@ open class KolodaView: UIView, DraggableCardDelegate {
     
     public weak var delegate: KolodaViewDelegate?
     
-    public lazy var animator: KolodaViewAnimator = {
+    public private(set) lazy var animator: KolodaViewAnimator = {
         return KolodaViewAnimator(koloda: self)
     }()
     


### PR DESCRIPTION
When Koloda is built with Carthage and added to a project which uses Xcode 8 & Swift 3 there is a linker error about a subclass of `KolodaView` named `CustomKolodaView`. It seems to be about the a lazy variable named `animator`.

`direct field offset for Koloda.KolodaView.(animator.storage in _DF55D12D516409CF60937DD60F8B896 Koloda.KolodaViewAnimator?", referenced from: ...`

![error](https://cloud.githubusercontent.com/assets/1845482/19899464/3fc29408-a02e-11e6-9a02-73e4308561ef.png)

Making the setter of the lazy variable private resolves the issue.
