### PR TITLE
Fixed the linker error when using Carthage to build Koloda library with Xcode 8

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -90,7 +90,16 @@ open class KolodaView: UIView, DraggableCardDelegate {
     
     public weak var delegate: KolodaViewDelegate?
     
-    public lazy var animator: KolodaViewAnimator = {
+    public var animator: KolodaViewAnimator {
+        set {
+            self._animator = newValue
+        }
+        get {
+            return self._animator
+        }
+    }
+    
+    private lazy var _animator: KolodaViewAnimator = {
         return KolodaViewAnimator(koloda: self)
     }()
     


### PR DESCRIPTION
When Koloda is built with Carthage and added to a project which uses Xcode 8 & Swift 3 there is a linker error about a subclass of `KolodaView` named `CustomKolodaView`. It seems to be about the a lazy variable named `animator`.

`Undefined symbols for architecture x86_64:
"direct field offset for Koloda.KolodaView.(animator.storage in _DF55D12D516409CF60937DD60F8B896 Koloda.KolodaViewAnimator?", referenced from: ...
ld: symbol(s) not found for architecture x86_64`

<img width="705" alt="error" src="https://cloud.githubusercontent.com/assets/1845482/21471741/f528510a-cac4-11e6-9222-9d1247dfcee5.png">

Making the setter of the lazy variable private resolves the issue. But as the setter can be used by others (just like in the example project with the `BackgroundKolodaAnimator`) I had to make it private and create another public variable that is not `lazy` which helps accessing the original `animator`.