### PR TITLE
Make Koloda more flexible

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -653,7 +653,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
             let card = visibleCards[visibleCardIndex]
             card.delegate = nil
             if animated {
-                card.swipe(.Right)
+                animator.removeCardAnimation(card)
             } else {
                 card.removeFromSuperview()
             }

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -646,13 +646,17 @@ public class KolodaView: UIView, DraggableCardDelegate {
     
     // MARK: Cards managing - Deletion
     
-    private func proceedDeletionInRange(range: Range<Int>) {
+    private func proceedDeletionInRange(range: Range<Int>, animated: Bool) {
         let deletionIndexes = [Int](range)
         deletionIndexes.sort { $0 > $1 }.forEach { deletionIndex in
             let visibleCardIndex = deletionIndex - currentCardIndex
             let card = visibleCards[visibleCardIndex]
             card.delegate = nil
-            card.swipe(.Right)
+            if animated {
+                card.swipe(.Right)
+            } else {
+                card.removeFromSuperview()
+            }
             visibleCards.removeAtIndex(visibleCardIndex)
         }
     }
@@ -667,7 +671,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
         countOfCards = Int(dataSource.kolodaNumberOfCards(self))
         let visibleIndexes = [Int](indexRange).filter { $0 >= currentCardIndex && $0 < currentCardIndex + countOfVisibleCards }
         if !visibleIndexes.isEmpty {
-            proceedDeletionInRange(visibleIndexes[0]...visibleIndexes[visibleIndexes.count - 1])
+            proceedDeletionInRange(visibleIndexes[0]...visibleIndexes[visibleIndexes.count - 1], animated: animated)
         }
         currentCardIndex -= Array(indexRange).filter { $0 < currentCardIndex }.count
         loadMissingCards(missingCardsCount())

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -393,8 +393,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
             var animationCompletion: ((Bool) -> Void)? = nil
             if index != 0 {
                 if shouldTransparentizeNextCard {
-                    let alphaTransparent: CGFloat = delegate != nil ? delegate!.kolodaOpacityForNextCard(self, at: index) : alphaValueSemiTransparent
-                    currentCard.alpha = alphaTransparent
+                    currentCard.alpha = cardAlphaTransparent(at: index)
                 }
             } else {
                 animationCompletion = { finished in
@@ -453,8 +452,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
             
             for (index, card) in visibleCards.dropFirst().enumerate() {
                 if shouldTransparentizeNextCard {
-                    let alphaTransparent: CGFloat = delegate != nil ? delegate!.kolodaOpacityForNextCard(self, at: index) : alphaValueSemiTransparent
-                    card.alpha = alphaTransparent
+                    card.alpha = cardAlphaTransparent(at: index)
                 }
                 card.userInteractionEnabled = false
                 
@@ -543,8 +541,11 @@ public class KolodaView: UIView, DraggableCardDelegate {
                 animating = true
                 
                 if visibleCards.count > 1 {
-                    let nextCard = visibleCards[1]
-                    nextCard.alpha = shouldTransparentizeNextCard ? alphaValueSemiTransparent : alphaValueOpaque
+                    for i in 1..<visibleCards.count {
+                        let nextCard = visibleCards[i]
+                        let alpha = cardAlphaTransparent(at: i)
+                        nextCard.alpha = shouldTransparentizeNextCard ? alpha : alphaValueOpaque
+                    }
                 }
                 frontCard.swipe(direction)
                 frontCard.delegate = nil
@@ -587,7 +588,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
                 insertSubview(card, atIndex: visibleCards.count - 1)
             } else {
                 card.userInteractionEnabled = false
-                card.alpha = shouldTransparentizeNextCard ? alphaValueSemiTransparent : alphaValueOpaque
+                card.alpha = shouldTransparentizeNextCard ? cardAlphaTransparent(at: visibleCardIndex) : alphaValueOpaque
                 insertSubview(card, belowSubview: visibleCards[visibleCardIndex - 1])
             }
             layoutCard(card, atIndex: UInt(visibleCardIndex))
@@ -680,7 +681,7 @@ public class KolodaView: UIView, DraggableCardDelegate {
         loadMissingCards(missingCardsCount())
         layoutDeck()
         for (index, card) in visibleCards.enumerate() {
-            card.alpha = shouldTransparentizeNextCard && index != 0 ? alphaValueSemiTransparent : alphaValueOpaque
+            card.alpha = shouldTransparentizeNextCard && index != 0 ? cardAlphaTransparent(at: index) : alphaValueOpaque
             card.userInteractionEnabled = index == 0
         }
         animating = false

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -15,6 +15,7 @@ private let defaultBackgroundCardsTopMargin: CGFloat = 4.0
 private let defaultBackgroundCardsScalePercent: CGFloat = 0.95
 private let defaultBackgroundCardsLeftMargin: CGFloat = 8.0
 private let defaultBackgroundCardFrameAnimationDuration: NSTimeInterval = 0.2
+private let defaultAppearanceAnimationDuration: NSTimeInterval = 0.8
 
 //Opacity values
 private let defaultAlphaValueOpaque: CGFloat = 1.0
@@ -82,6 +83,8 @@ public class KolodaView: UIView, DraggableCardDelegate {
     public var alphaValueTransparent = defaultAlphaValueTransparent
     public var alphaValueSemiTransparent = defaultAlphaValueSemiTransparent
     public var shouldPassthroughTapsWhenNoVisibleCards = false
+    
+    public var appearanceAnimationDuration = defaultAppearanceAnimationDuration
     
     public weak var dataSource: KolodaViewDataSource? {
         didSet {
@@ -235,10 +238,10 @@ public class KolodaView: UIView, DraggableCardDelegate {
         userInteractionEnabled = false
         animating = true
         
-        animator.animateAppearanceWithCompletion { [weak self] _ in
+        animator.animateAppearance(appearanceAnimationDuration, completion: { [weak self] _ in
             self?.userInteractionEnabled = true
             self?.animating = false
-        }
+        })
     }
     
     public func applyAppearAnimationIfNeeded() {

--- a/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
+++ b/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
@@ -20,11 +20,11 @@ public class KolodaViewAnimator {
         self.koloda = koloda
     }
     
-    public func animateAppearanceWithCompletion(completion: AnimationCompletionBlock = nil) {
+    public func animateAppearance(duration: NSTimeInterval, completion: AnimationCompletionBlock = nil) {
         let kolodaAppearScaleAnimation = POPBasicAnimation(propertyNamed: kPOPLayerScaleXY)
         
         kolodaAppearScaleAnimation.beginTime = CACurrentMediaTime() + cardSwipeActionAnimationDuration
-        kolodaAppearScaleAnimation.duration = 0.8
+        kolodaAppearScaleAnimation.duration = duration
         kolodaAppearScaleAnimation.fromValue = NSValue(CGPoint: CGPoint(x: 0.1, y: 0.1))
         kolodaAppearScaleAnimation.toValue = NSValue(CGPoint: CGPoint(x: 1.0, y: 1.0))
         kolodaAppearScaleAnimation.completionBlock = { (_, finished) in
@@ -36,7 +36,7 @@ public class KolodaViewAnimator {
         kolodaAppearAlphaAnimation.beginTime = CACurrentMediaTime() + cardSwipeActionAnimationDuration
         kolodaAppearAlphaAnimation.fromValue = NSNumber(float: 0.0)
         kolodaAppearAlphaAnimation.toValue = NSNumber(float: 1.0)
-        kolodaAppearAlphaAnimation.duration = 0.8
+        kolodaAppearAlphaAnimation.duration = duration
         
         koloda?.pop_addAnimation(kolodaAppearAlphaAnimation, forKey: "kolodaAppearScaleAnimation")
         koloda?.layer.pop_addAnimation(kolodaAppearScaleAnimation, forKey: "kolodaAppearAlphaAnimation")

--- a/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
+++ b/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
@@ -107,6 +107,12 @@ public class KolodaViewAnimator {
         )
     }
     
+    public func removeCardAnimation(card: DraggableCardView, completion: AnimationCompletionBlock = nil) {
+        card.swipe(.Right)
+        completion?(true)
+    }
+
+    
     internal func resetBackgroundCardsWithCompletion(completion: AnimationCompletionBlock = nil) {
         UIView.animateWithDuration(
             0.2,


### PR DESCRIPTION
Hi,

Here's a couple of changes (for 3.X version0 I made to:

- allow different values of alpha for visible cards depending on their index
- Delegate type of animation for `removeCardInIndexRange` to animator instead of default swipe right
- change animation duration (superseed #262)
- Consider animated flag in removeCardInIndexRange

Let me know if you want me to split them up + porting to swift 3 for 4.0 version