### PR TITLE
Use default drag speed when not specified

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -35,7 +35,10 @@ public extension KolodaViewDataSource {
     func koloda(_ koloda: KolodaView, viewForCardOverlayAt index: Int) -> OverlayView? {
         return nil
     }
-    
+ 
+    func kolodaSpeedThatCardShouldDrag(_ koloda: KolodaView) -> DragSpeed {
+		return .default
+	}
 }
 
 public protocol KolodaViewDelegate: class {


### PR DESCRIPTION
This adds a default implementation of `kolodaSpeedThatCardShouldDrag` so that the datasource isn't compelled to provide one when the default speed is sufficient.