### PR TITLE
[FIX] animation increment added

### DIFF
--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -281,6 +281,7 @@ open class KolodaView: UIView, DraggableCardDelegate {
     // MARK: DraggableCardDelegate
     
     func card(_ card: DraggableCardView, wasDraggedWithFinishPercentage percentage: CGFloat, inDirection direction: SwipeResultDirection) {
+        animationSemaphore.increment()
         
         if let shouldMove = delegate?.kolodaShouldMoveBackgroundCard(self), shouldMove {
             self.moveOtherCardsWithPercentage(percentage)


### PR DESCRIPTION
Fix an issue when you set:
kolodaSwipeThresholdRatioMargin through KolodaViewDelegate to 0.4 (for example) -  it will cause card slightly jumping (when drag slowly) or returning to it original position (about 0.1 sec) and then disappear with animation (when swipe fast). It looks like two cards (the same) disappearing. I look between 4.3.1 and 4.3 tag and found difference.