### PR TITLE
Fix Swift 4.1 warning

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -321,7 +321,7 @@ public class DraggableCardView: UIView, UIGestureRecognizerDelegate {
             // check 4 borders for intersection with line between touchpoint and center of card
             // return smallest percentage of distance to edge point or 0
             return rect.perimeterLines
-                        .flatMap { CGPoint.intersectionBetweenLines(targetLine, line2: $0) }
+                        .compactMap { CGPoint.intersectionBetweenLines(targetLine, line2: $0) }
                         .map { centerDistance / $0.distanceTo(.zero) }
                         .min() ?? 0
         }


### PR DESCRIPTION
Fix a Swift 4.1 warning by converting usage of the deprecated `flatMap` to `compactMap`