### PR TITLE
Fix issue #375

### DIFF
--- a/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
+++ b/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
@@ -96,11 +96,14 @@ open class KolodaViewAnimator {
     }
     
     open func applyInsertionAnimation(_ cards: [DraggableCardView], completion: AnimationCompletionBlock = nil) {
+        let initialAlphas = cards.map { $0.alpha }
         cards.forEach { $0.alpha = 0.0 }
         UIView.animate(
             withDuration: 0.2,
             animations: {
-                cards.forEach { $0.alpha = 1.0 }
+                for (i, card) in cards.enumerated() {
+                    card.alpha = initialAlphas[i]
+                }
             },
             completion: { finished in
                 completion?(finished)


### PR DESCRIPTION
Ensure that the inserted card's initial alpha is used as the final alpha value at the end of the insertion animation.