### PR TITLE
Changed the accessibility of DraggableCardView's contentView

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -57,7 +57,7 @@ public class DraggableCardView: UIView, UIGestureRecognizerDelegate {
     }
     
     private var overlayView: OverlayView?
-    private(set) var contentView: UIView?
+    public private(set) var contentView: UIView?
     
     private var panGestureRecognizer: UIPanGestureRecognizer!
     private var tapGestureRecognizer: UITapGestureRecognizer!


### PR DESCRIPTION
I am very happy, and thanks for merging 'isLoop' property.
I have one more thing I want the contentView in DraggableCardView is more open. Then I can interact with contentView direct.

for example, I am controlling the animation of contentView in some condition.

    let cards:[DraggableCardView] = subviews.filter{ $0 as? DraggableCardView != nil } as! [DraggableCardView]
    for c in cards {
        if let g = c.contentView as? EmptyCardView {
            if isVisible { // some condition
                g.resumeAnim()
            } else {
                g.pauseAnim()
            }
        }
    }
