### PR TITLE
prevent layoutDeck from being called during panGesture.

### DIFF
--- a/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
+++ b/Pod/Classes/KolodaView/DraggableCardView/DraggableCardView.swift
@@ -57,6 +57,8 @@ public class DraggableCardView: UIView, UIGestureRecognizerDelegate {
             configureSwipeSpeed()
         }
     }
+
+    internal var dragBegin = false
     
     private var overlayView: OverlayView?
     public private(set) var contentView: UIView?
@@ -64,7 +66,6 @@ public class DraggableCardView: UIView, UIGestureRecognizerDelegate {
     private var panGestureRecognizer: UIPanGestureRecognizer!
     private var tapGestureRecognizer: UITapGestureRecognizer!
     private var animationDirectionY: CGFloat = 1.0
-    private var dragBegin = false
     private var dragDistance = CGPoint.zero
     private var swipePercentageMargin: CGFloat = 0.0
 

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -150,12 +150,17 @@ open class KolodaView: UIView, DraggableCardDelegate {
         return KolodaViewAnimator(koloda: self)
     }()
     private var visibleCards = [DraggableCardView]()
+    private var cardsDragging: Bool {
+        return visibleCards.contains { card in
+            return card.dragBegin
+        }
+    }
 
     
     override open func layoutSubviews() {
         super.layoutSubviews()
         
-        if !animationSemaphore.isAnimating {
+        if !animationSemaphore.isAnimating, !cardsDragging {
             layoutDeck()
         }
     }

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -150,17 +150,18 @@ open class KolodaView: UIView, DraggableCardDelegate {
         return KolodaViewAnimator(koloda: self)
     }()
     private var visibleCards = [DraggableCardView]()
-    private var cardsDragging: Bool {
-        return visibleCards.contains { card in
-            return card.dragBegin
+
+    private var cardIsDragging: Bool {
+        guard let frontCard = visibleCards.first else {
+            return false
         }
+        return frontCard.dragBegin
     }
 
-    
     override open func layoutSubviews() {
         super.layoutSubviews()
         
-        if !animationSemaphore.isAnimating, !cardsDragging {
+        if !animationSemaphore.isAnimating, !cardIsDragging {
             layoutDeck()
         }
     }


### PR DESCRIPTION
Sometimes,`layoutDeck()` was called from `KolodaView` `layoutSubviews()` during a `DraggableCardView` pan, causing the current card to flicker.
To prevent this, expose `dragBegin` property, and check the front card is not panning before calling `layoutDeck()`

Addresses #386 