### PR TITLE
Carthage dependency redirection

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "facebook/pop" ~> 1.0
+github "facebookarchive/pop" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "facebook/pop" "1.0.12"
+github "facebookarchive/pop" "1.0.12"


### PR DESCRIPTION
Pop has been moved to [facebookarchive/pop](https://github.com/facebookarchive/pop).

While Carthage does redirect requests for downloads, the authentication for Github's API doesn't always follow the redirect.  This can cause problems on some CI systems, [notably bitrise](https://discuss.bitrise.io/t/api-rate-limit-error/238/11).  In this case, the lack of redirect means Carthage has to rebuild Pop when a perfectly good binary is available.

This PR sets pop's source in both the Cartfile & its resolved file accordingly so such a redirect isn't needed.