### PR TITLE
Replace pop with UIView animations

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "facebook/pop" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "facebook/pop" "1.0.12"

--- a/Example/Koloda.xcodeproj/project.pbxproj
+++ b/Example/Koloda.xcodeproj/project.pbxproj
@@ -234,12 +234,10 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Koloda_Example/Pods-Koloda_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Koloda/Koloda.framework",
-				"${BUILT_PRODUCTS_DIR}/pop/pop.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Koloda.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/pop.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -404,6 +402,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Koloda/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yalantis.Koloda-Example";
@@ -420,6 +419,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Koloda/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yalantis.Koloda-Example";

--- a/Example/Koloda/BackgroundAnimationViewController.swift
+++ b/Example/Koloda/BackgroundAnimationViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import Koloda
-import pop
 
 private let numberOfCards: Int = 5
 private let frameAnimationSpringBounciness: CGFloat = 9
@@ -70,11 +69,8 @@ extension BackgroundAnimationViewController: KolodaViewDelegate {
         return true
     }
     
-    func koloda(kolodaBackgroundCardAnimation koloda: KolodaView) -> POPPropertyAnimation? {
-        let animation = POPSpringAnimation(propertyNamed: kPOPViewFrame)
-        animation?.springBounciness = frameAnimationSpringBounciness
-        animation?.springSpeed = frameAnimationSpringSpeed
-        return animation
+    func koloda(kolodaBackgroundCardAnimation koloda: KolodaView) -> UIViewPropertyAnimator? {
+        return UIViewPropertyAnimator(duration: 0.2, dampingRatio: (frameAnimationSpringBounciness - 20) / 20, animations: nil)
     }
 }
 

--- a/Example/Koloda/BackgroundKolodaAnimator.swift
+++ b/Example/Koloda/BackgroundKolodaAnimator.swift
@@ -8,28 +8,21 @@
 
 import Foundation
 import Koloda
-import pop
 
 class BackgroundKolodaAnimator: KolodaViewAnimator {
     
     override func applyScaleAnimation(_ card: DraggableCardView, scale: CGSize, frame: CGRect, duration: TimeInterval, completion: AnimationCompletionBlock) {
-        
-        let scaleAnimation = POPSpringAnimation(propertyNamed: kPOPLayerScaleXY)
-        scaleAnimation?.springBounciness = 9
-        scaleAnimation?.springSpeed = 16
-        scaleAnimation?.toValue = NSValue(cgSize: scale)
-        card.layer.pop_add(scaleAnimation, forKey: "scaleAnimation")
-        
-        let frameAnimation = POPSpringAnimation(propertyNamed: kPOPViewFrame)
-        frameAnimation?.springBounciness = 9
-        frameAnimation?.springSpeed = 16
-        frameAnimation?.toValue = NSValue(cgRect: frame)
+
+        let animation = UIViewPropertyAnimator(duration: duration, dampingRatio: 0.7) {
+            card.transform = CGAffineTransform(scaleX: scale.width, y: scale.height)
+            card.frame = frame
+        }
         if let completion = completion {
-            frameAnimation?.completionBlock = { _, finished in
-                completion(finished)
+            animation.addCompletion { position in
+                completion(position == .end)
             }
         }
-        card.pop_add(frameAnimation, forKey: "frameAnimation")
+        animation.startAnimation()
     }
     
 }

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,3 +1,5 @@
+platform :ios, '10.0'
+
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 

--- a/Koloda.podspec
+++ b/Koloda.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name             = 'Koloda'
-	s.version          = '5.0.1'
+	s.version          = '5.0.2'
 	s.summary          = 'KolodaView is a class designed to simplify the implementation of Tinder like cards on iOS. '
 
 	s.homepage         = 'https://github.com/Yalantis/Koloda'
@@ -9,9 +9,8 @@ Pod::Spec.new do |s|
 	s.source           = { :git => 'https://github.com/Yalantis/Koloda.git', :tag => s.version }
 	s.social_media_url = 'https://twitter.com/yalantis'
 
-	s.platform     = :ios, '8.0'
+	s.platform     = :ios, '10.0'
 	s.source_files = 'Pod/Classes/**/*'
 
 	s.frameworks = 'UIKit'
-	s.dependency 'pop', '~> 1.0'
 end

--- a/Koloda.xcodeproj/project.pbxproj
+++ b/Koloda.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = C517E4A11D9CF9010002D88F;
@@ -328,6 +329,7 @@
 				);
 				INFOPLIST_FILE = Pod/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.Koloda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -350,6 +352,7 @@
 				);
 				INFOPLIST_FILE = Pod/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.Koloda;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Pod/Classes/KolodaView/KolodaView.swift
+++ b/Pod/Classes/KolodaView/KolodaView.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import pop
 
 // Default values
 private let defaultCountOfVisibleCards = 3

--- a/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
+++ b/Pod/Classes/KolodaView/KolodaViewAnimatior.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import UIKit
-import pop
 
 open class KolodaViewAnimator {
     
@@ -21,78 +20,59 @@ open class KolodaViewAnimator {
     }
     
     open func animateAppearance(_ duration: TimeInterval, completion: AnimationCompletionBlock = nil) {
-        let kolodaAppearScaleAnimation = POPBasicAnimation(propertyNamed: kPOPLayerScaleXY)
-        
-        kolodaAppearScaleAnimation?.beginTime = CACurrentMediaTime() + cardSwipeActionAnimationDuration
-        kolodaAppearScaleAnimation?.duration = duration
-        kolodaAppearScaleAnimation?.fromValue = NSValue(cgPoint: CGPoint(x: 0.1, y: 0.1))
-        kolodaAppearScaleAnimation?.toValue = NSValue(cgPoint: CGPoint(x: 1.0, y: 1.0))
-        kolodaAppearScaleAnimation?.completionBlock = { (_, finished) in
-            completion?(finished)
+
+        koloda?.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+        koloda?.alpha = 0
+
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: cardSwipeActionAnimationDuration, options: []) {
+            self.koloda?.transform = CGAffineTransform(scaleX: 1, y: 1)
+        } completion: { position in
+            completion?(position == .end)
         }
         
-        let kolodaAppearAlphaAnimation = POPBasicAnimation(propertyNamed: kPOPViewAlpha)
-        
-        kolodaAppearAlphaAnimation?.beginTime = CACurrentMediaTime() + cardSwipeActionAnimationDuration
-        kolodaAppearAlphaAnimation?.fromValue = NSNumber(value: 0.0)
-        kolodaAppearAlphaAnimation?.toValue = NSNumber(value: 1.0)
-        kolodaAppearAlphaAnimation?.duration = duration
-        
-        koloda?.pop_add(kolodaAppearAlphaAnimation, forKey: "kolodaAppearScaleAnimation")
-        koloda?.layer.pop_add(kolodaAppearScaleAnimation, forKey: "kolodaAppearAlphaAnimation")
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: cardSwipeActionAnimationDuration, options: []) {
+            self.koloda?.alpha = 1
+        }
     }
     
     open func applyReverseAnimation(_ card: DraggableCardView, direction: SwipeResultDirection?, duration: TimeInterval, completion: AnimationCompletionBlock = nil) {
-        let alphaAnimation = POPBasicAnimation(propertyNamed: kPOPViewAlpha)
-        alphaAnimation?.fromValue =  NSNumber(value: 0.0)
-        alphaAnimation?.toValue = NSNumber(value: 1.0)
-        alphaAnimation?.duration = direction != nil ? duration : 1.0
-        alphaAnimation?.completionBlock = { _, finished in
-            completion?(finished)
+
+        card.alpha = 0
+
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: direction != nil ? duration : 1.0, delay: 0, options: []) {
+            card.alpha = 1
+        } completion: { position in
+            completion?(position == .end)
             card.alpha = 1.0
         }
-        card.pop_add(alphaAnimation, forKey: "reverseCardAlphaAnimation")
         
         guard let direction = direction else { return }
-        
-        let translationAnimation = POPBasicAnimation(propertyNamed: kPOPLayerTranslationXY)
-        translationAnimation?.fromValue = NSValue(cgPoint: card.animationPointForDirection(direction))
-        translationAnimation?.toValue = NSValue(cgPoint: CGPoint.zero)
-        translationAnimation?.duration = duration
-        card.layer.pop_add(translationAnimation, forKey: "reverseCardTranslationAnimation")
-        
-        let rotationAnimation = POPBasicAnimation(propertyNamed: kPOPLayerRotation)
-        rotationAnimation?.fromValue = CGFloat(card.animationRotationForDirection(direction))
-        rotationAnimation?.toValue = CGFloat(0.0)
-        rotationAnimation?.duration = duration
-        card.layer.pop_add(rotationAnimation, forKey: "reverseCardRotationAnimation")
+
+        let animationPoint = card.animationPointForDirection(direction)
+        let animationRotation = card.animationRotationForDirection(direction)
+        card.transform = CGAffineTransform(translationX: animationPoint.x, y: animationPoint.y)
+            .rotated(by: animationRotation)
+
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: 0, options: []) {
+            card.transform = .identity
+        }
     }
     
     open func applyScaleAnimation(_ card: DraggableCardView, scale: CGSize, frame: CGRect, duration: TimeInterval, completion: AnimationCompletionBlock = nil) {
-        let scaleAnimation = POPBasicAnimation(propertyNamed: kPOPLayerScaleXY)
-        scaleAnimation?.duration = duration
-        scaleAnimation?.toValue = NSValue(cgSize: scale)
-        card.layer.pop_add(scaleAnimation, forKey: "scaleAnimation")
-        
-        let frameAnimation = POPBasicAnimation(propertyNamed: kPOPViewFrame)
-        frameAnimation?.duration = duration
-        frameAnimation?.toValue = NSValue(cgRect: frame)
-        if let completion = completion {
-            frameAnimation?.completionBlock = { _, finished in
-                completion(finished)
-            }
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: 0, options: []) {
+            card.transform = CGAffineTransform(scaleX: scale.width, y: scale.height)
+            card.frame = frame
+        } completion: { position in
+            completion?(position == .end)
         }
-        card.pop_add(frameAnimation, forKey: "frameAnimation")
     }
     
     open func applyAlphaAnimation(_ card: DraggableCardView, alpha: CGFloat, duration: TimeInterval = 0.2, completion: AnimationCompletionBlock = nil) {
-        let alphaAnimation = POPBasicAnimation(propertyNamed: kPOPViewAlpha)
-        alphaAnimation?.toValue = alpha
-        alphaAnimation?.duration = duration
-        alphaAnimation?.completionBlock = { _, finished in
-            completion?(finished)
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: 0, options: []) {
+            card.alpha = alpha
+        } completion: { position in
+            completion?(position == .end)
         }
-        card.pop_add(alphaAnimation, forKey: "alpha")
     }
     
     open func applyInsertionAnimation(_ cards: [DraggableCardView], completion: AnimationCompletionBlock = nil) {


### PR DESCRIPTION
pop has been deprecated by Facebook. This PR replaces pop animations with standard UIView animations. I also bumped the deployment target to iOS 10 which is when UIView property animations were introduced.